### PR TITLE
Add options to control eager loading of rails app

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ PigCI.start do |config|
 
   # E.g. disable terminal summary output
   config.generate_terminal_summary = false
-end # if RSpec.configuration.files_to_run.count > 1
+end # if ENV['RUN_PIG_CI'] || RSpec.configuration.files_to_run.count > 1
 ```
 
 You can see the full configuration options [lib/pig_ci.rb](https://github.com/PigCI/pig-ci-rails/blob/master/lib/pig_ci.rb#L21).
@@ -78,27 +78,33 @@ Currently this gem only supports Ruby on Rails.
 
 ### Metric notes
 
-#### Memory
-
 Minor fluctuations in memory usage and request time are to be expected and are nothing to worry about. Though any large spike is a signal of something worth investigating.
 
-You can improve its accuracy by updating your `config/environments/test.rb` to have the line:
+#### Memory
+
+By default, this gem will tell Rails to eager load your application on startup. This aims to help identify leaks, over just pure bulk.
+
+You can disable this functionality by setting your configuration to be:
 
 ```ruby
-config.eager_load = true
+require 'pig_ci'
+PigCI.start do |config|
+  config.during_setup_eager_load_application = false
+end
 ```
 
 #### Request Time
 
-Often the first request test will be slow, as rails is loading a full environment. While this metric is useful, I'd suggest focusing on other metrics (like memory, or database requests).
+Often the first request test will be slow, as rails is loading a full environment. To mitigate this issue, this gem will make a blank request to your application before your test suite starts.
 
-Alternatively add:
+You can disable this functionality by setting your configuration to be:
 
 ```ruby
-Rails.application.call(::Rack::MockRequest.env_for('/'))
+require 'pig_ci'
+PigCI.start do |config|
+  config.during_setup_make_blank_application_request = false
+end
 ```
-
-Before you call `PigCI.start`.
 
 ## Authors
 

--- a/lib/pig_ci.rb
+++ b/lib/pig_ci.rb
@@ -45,6 +45,16 @@ module PigCI
     @report_memory_precision || 2
   end
 
+  attr_writer :during_setup_eager_load_application
+  def during_setup_eager_load_application?
+    @during_setup_eager_load_application.nil? || @during_setup_eager_load_application
+  end
+
+  attr_writer :during_setup_make_blank_application_request
+  def during_setup_make_blank_application_request?
+    @during_setup_make_blank_application_request.nil? || @during_setup_make_blank_application_request
+  end
+
   attr_writer :terminal_report_row_limit
   def terminal_report_row_limit
     @terminal_report_row_limit || -1

--- a/lib/pig_ci/profiler_engine/rails.rb
+++ b/lib/pig_ci/profiler_engine/rails.rb
@@ -21,6 +21,7 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
   def setup!
     super do
       eager_load_rails!
+      make_blank_application_request!
     end
   end
 
@@ -31,7 +32,9 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
     ::Rails.application.eager_load!
     ::Rails::Engine.subclasses.map(&:instance).each(&:eager_load!)
     ::ActiveRecord::Base.descendants
+  end
 
+  def make_blank_application_request!
     # Make a call to the root path to load up as much of rails as possible
     ::Rails.application.call(::Rack::MockRequest.env_for('/'))
   end

--- a/lib/pig_ci/profiler_engine/rails.rb
+++ b/lib/pig_ci/profiler_engine/rails.rb
@@ -20,8 +20,8 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
 
   def setup!
     super do
-      eager_load_rails!
-      make_blank_application_request!
+      eager_load_rails! if PigCI.during_setup_eager_load_application?
+      make_blank_application_request! if PigCI.during_setup_make_blank_application_request?
     end
   end
 

--- a/spec/lib/pig_ci/profiler_engine/rails_spec.rb
+++ b/spec/lib/pig_ci/profiler_engine/rails_spec.rb
@@ -19,7 +19,7 @@ describe PigCI::ProfilerEngine do
 
     context 'with PigCI.during_setup_eager_load_application set to false' do
       before { PigCI.during_setup_eager_load_application = false }
-      after { PigCI.during_setup_eager_load_application = true }
+      after { PigCI.during_setup_eager_load_application = nil }
       it do
         expect(profiler_engine).to_not receive(:eager_load_rails!)
         subject
@@ -28,7 +28,7 @@ describe PigCI::ProfilerEngine do
 
     context 'with PigCI.during_setup_make_blank_application_request set to false' do
       before { PigCI.during_setup_make_blank_application_request = false }
-      after { PigCI.during_setup_make_blank_application_request = true }
+      after { PigCI.during_setup_make_blank_application_request = nil }
       it do
         expect(profiler_engine).to_not receive(:make_blank_application_request!)
         subject

--- a/spec/lib/pig_ci/profiler_engine/rails_spec.rb
+++ b/spec/lib/pig_ci/profiler_engine/rails_spec.rb
@@ -8,6 +8,34 @@ describe PigCI::ProfilerEngine do
     allow(Rails.application).to receive(:call)
   end
 
+  describe '#setup!' do
+    subject { profiler_engine.setup! }
+
+    it do
+      expect(profiler_engine).to receive(:eager_load_rails!)
+      expect(profiler_engine).to receive(:make_blank_application_request!)
+      subject
+    end
+
+    context 'with PigCI.during_setup_eager_load_application set to false' do
+      before { PigCI.during_setup_eager_load_application = false }
+      after { PigCI.during_setup_eager_load_application = true }
+      it do
+        expect(profiler_engine).to_not receive(:eager_load_rails!)
+        subject
+      end
+    end
+
+    context 'with PigCI.during_setup_make_blank_application_request set to false' do
+      before { PigCI.during_setup_make_blank_application_request = false }
+      after { PigCI.during_setup_make_blank_application_request = true }
+      it do
+        expect(profiler_engine).to_not receive(:make_blank_application_request!)
+        subject
+      end
+    end
+  end
+
   describe '#profilers' do
     subject { profiler_engine.profilers }
     it { expect(subject.count).to eq(3) }


### PR DESCRIPTION
To get the most accurate Memory/Request Time results, it's good to preload as much of the app as possible so by default PigCI does this. 

However, I thought it would be good to allow this setting to be controllable. This adds the options:

- `PigCI.during_setup_make_blank_application_request`
- `PigCI.during_setup_eager_load_application`

## TODO

 - [x] Document in README.