### PR TITLE
Fixing issue where timezone would becomes the machines on app warmup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.2
 
 * Codacy changes
+* Correcting issue where app warm up would negatively affect timezone.
 
 ## 0.1.1
 

--- a/lib/pig_ci/profiler_engine/rails.rb
+++ b/lib/pig_ci/profiler_engine/rails.rb
@@ -36,7 +36,10 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
 
   def make_blank_application_request!
     # Make a call to the root path to load up as much of rails as possible
-    ::Rails.application.call(::Rack::MockRequest.env_for('/'))
+    # Done within a timezone block as it affects the timezone.
+    Time.use_zone('UTC') do
+      ::Rails.application.call(::Rack::MockRequest.env_for('/'))
+    end
   end
 
   def attach_listeners!

--- a/spec/lib/pig_ci/profiler_engine/rails_spec.rb
+++ b/spec/lib/pig_ci/profiler_engine/rails_spec.rb
@@ -36,6 +36,14 @@ describe PigCI::ProfilerEngine do
     end
   end
 
+  describe '#make_blank_application_request!' do
+    subject { profiler_engine.send(:make_blank_application_request!) }
+
+    it 'does not changes the current timezone' do
+      expect { subject }.to_not change(Time, :zone)
+    end
+  end
+
   describe '#profilers' do
     subject { profiler_engine.profilers }
     it { expect(subject.count).to eq(3) }


### PR DESCRIPTION
I found an issue where my app preboot technique was affecting timezones settings.

To correct the app warmup now reverts its timezone to the original when zone.