### PR TITLE
Gracefully handling SockerError when submitting reports while offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3
+
+* [Gracefully handling SockerError when submitting reports while offline](https://github.com/PigCI/pig-ci-rails/pull/7)
+
 ## 0.1.2
 
 * [Improving Codacy Rating](https://github.com/PigCI/pig-ci-rails/pull/4)

--- a/lib/pig_ci/api/reports.rb
+++ b/lib/pig_ci/api/reports.rb
@@ -10,6 +10,8 @@ class PigCI::Api::Reports < PigCI::Api
     puts I18n.t('pig_ci.api.reports.error', error: JSON.parse(response.parsed_response || '{}')['error'])
   rescue JSON::ParserError => _e
     puts I18n.t('pig_ci.api.reports.api_error')
+  rescue SocketError => e
+    puts I18n.t('pig_ci.api.reports.error', error: e)
   rescue Net::OpenTimeout => e
     puts I18n.t('pig_ci.api.reports.error', error: e.inspect)
   end

--- a/spec/lib/pig_ci/api/reports_spec.rb
+++ b/spec/lib/pig_ci/api/reports_spec.rb
@@ -13,6 +13,15 @@ describe PigCI::Api::Reports do
   describe '#share!' do
     subject { api.share! }
 
+    context 'User is offline' do
+      before do
+        stub_request(:post, 'https://api.pigci.com/api/v1/reports').to_raise(SocketError)
+      end
+
+      it do
+        expect { subject }.to output(/Unable to connect to PigCI API/).to_stdout
+      end
+    end
     context 'PigCI is offline' do
       before do
         stub_request(:post, 'https://api.pigci.com/api/v1/reports').to_timeout


### PR DESCRIPTION
This was sent in from @tomkadwill - he noticed when he was offline the API would throw a very loud error.

This replaces the error with:

```
Unable to connect to PigCI API: Failed to open TCP connection to api.pigci.com:443 (getaddrinfo: nodename nor servname provided, or not known)
```