### PR TITLE
Precompile assets before tests run

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ end
 
 #### Request Time
 
-Often the first request test will be slow, as rails is loading a full environment. To mitigate this issue, this gem will make a blank request to your application before your test suite starts.
+Often the first request test will be slow, as rails is loading a full environment & rendering assets. To mitigate this issue, this gem will make a blank request to your application before your test suite starts & compiling assets.
 
 You can disable this functionality by setting your configuration to be:
 
@@ -104,13 +104,8 @@ You can disable this functionality by setting your configuration to be:
 require 'pig_ci'
 PigCI.start do |config|
   config.during_setup_make_blank_application_request = false
+  config.during_setup_precompile_assets = false
 end
-```
-
-You can also improve the first request performance (and overall memory usage) by precompiling your assets before running RSpec:
-
-```ruby
-bundle exec rake assets:precompile RAILS_ENV=test
 ```
 
 ## Authors

--- a/lib/pig_ci.rb
+++ b/lib/pig_ci.rb
@@ -1,5 +1,6 @@
 require 'active_support'
 require 'active_support/core_ext/string/inflections'
+require 'rake'
 
 require 'pig_ci/version'
 require 'pig_ci/api'
@@ -53,6 +54,11 @@ module PigCI
   attr_writer :during_setup_make_blank_application_request
   def during_setup_make_blank_application_request?
     @during_setup_make_blank_application_request.nil? || @during_setup_make_blank_application_request
+  end
+
+  attr_writer :during_setup_precompile_assets
+  def during_setup_precompile_assets?
+    @during_setup_precompile_assets.nil? || @during_setup_precompile_assets
   end
 
   attr_writer :terminal_report_row_limit

--- a/lib/pig_ci/profiler_engine/rails.rb
+++ b/lib/pig_ci/profiler_engine/rails.rb
@@ -46,9 +46,7 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
     # Make a call to the root path to load up as much of rails as possible
     # Done within a timezone block as it affects the timezone.
     Time.use_zone('UTC') do
-      if ::Rails.application.routes.url_helpers.method_defined?(:root_path)
-        ::Rails.application.call(::Rack::MockRequest.env_for(::Rails.application.routes.url_helpers.root_path))
-      end
+      ::Rails.application.call(::Rack::MockRequest.env_for('/'))
     end
   end
 

--- a/lib/pig_ci/profiler_engine/rails.rb
+++ b/lib/pig_ci/profiler_engine/rails.rb
@@ -38,7 +38,9 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
     # Make a call to the root path to load up as much of rails as possible
     # Done within a timezone block as it affects the timezone.
     Time.use_zone('UTC') do
-      ::Rails.application.call(::Rack::MockRequest.env_for('/'))
+      if ::Rails.application.routes.url_helpers.method_defined?(:root_path)
+        ::Rails.application.call(::Rack::MockRequest.env_for(::Rails.application.routes.url_helpers.root_path))
+      end
     end
   end
 

--- a/lib/pig_ci/profiler_engine/rails.rb
+++ b/lib/pig_ci/profiler_engine/rails.rb
@@ -20,6 +20,7 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
 
   def setup!
     super do
+      precompile_assets! if true
       eager_load_rails! if PigCI.during_setup_eager_load_application?
       make_blank_application_request! if PigCI.during_setup_make_blank_application_request?
     end
@@ -30,8 +31,15 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
   def eager_load_rails!
     # Eager load rails to give more accurate memory levels.
     ::Rails.application.eager_load!
+    ::Rails.application.routes.eager_load!
     ::Rails::Engine.subclasses.map(&:instance).each(&:eager_load!)
     ::ActiveRecord::Base.descendants
+  end
+
+  def precompile_assets!
+    # From: https://github.com/rails/sprockets-rails/blob/e9ca63edb6e658cdfcf8a35670c525b369c2ccca/test/test_railtie.rb#L7-L13
+    ::Rails.application.load_tasks
+    ::Rake.application['assets:precompile'].execute
   end
 
   def make_blank_application_request!

--- a/lib/pig_ci/profiler_engine/rails.rb
+++ b/lib/pig_ci/profiler_engine/rails.rb
@@ -20,7 +20,7 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
 
   def setup!
     super do
-      precompile_assets! if true
+      precompile_assets! if PigCI.during_setup_precompile_assets?
       eager_load_rails! if PigCI.during_setup_eager_load_application?
       make_blank_application_request! if PigCI.during_setup_make_blank_application_request?
     end
@@ -28,18 +28,18 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
 
   private
 
+  def precompile_assets!
+    # From: https://github.com/rails/sprockets-rails/blob/e9ca63edb6e658cdfcf8a35670c525b369c2ccca/test/test_railtie.rb#L7-L13
+    ::Rails.application.load_tasks
+    ::Rake.application['assets:precompile'].execute
+  end
+
   def eager_load_rails!
     # Eager load rails to give more accurate memory levels.
     ::Rails.application.eager_load!
     ::Rails.application.routes.eager_load!
     ::Rails::Engine.subclasses.map(&:instance).each(&:eager_load!)
     ::ActiveRecord::Base.descendants
-  end
-
-  def precompile_assets!
-    # From: https://github.com/rails/sprockets-rails/blob/e9ca63edb6e658cdfcf8a35670c525b369c2ccca/test/test_railtie.rb#L7-L13
-    ::Rails.application.load_tasks
-    ::Rake.application['assets:precompile'].execute
   end
 
   def make_blank_application_request!

--- a/spec/lib/pig_ci/profiler_engine/rails_spec.rb
+++ b/spec/lib/pig_ci/profiler_engine/rails_spec.rb
@@ -6,12 +6,14 @@ describe PigCI::ProfilerEngine do
   before do
     # Stub out the complex eager loading a little
     allow(Rails.application).to receive(:call)
+    allow(Rake.application).to receive(:[]).and_return(double(:rake_task, execute: true))
   end
 
   describe '#setup!' do
     subject { profiler_engine.setup! }
 
     it do
+      expect(profiler_engine).to receive(:precompile_assets!)
       expect(profiler_engine).to receive(:eager_load_rails!)
       expect(profiler_engine).to receive(:make_blank_application_request!)
       subject
@@ -31,6 +33,15 @@ describe PigCI::ProfilerEngine do
       after { PigCI.during_setup_make_blank_application_request = nil }
       it do
         expect(profiler_engine).to_not receive(:make_blank_application_request!)
+        subject
+      end
+    end
+
+    context 'with PigCI.during_setup_make_blank_application_request set to false' do
+      before { PigCI.during_setup_precompile_assets = false }
+      after { PigCI.during_setup_precompile_assets = nil }
+      it do
+        expect(profiler_engine).to_not receive(:precompile_assets!)
         subject
       end
     end


### PR DESCRIPTION
Precompiling the assets appear to improve the startup time of rails in the tests. This adds this feature