### PR TITLE
Widen i18n gem version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ end
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## TODO
 
 Features I'd like to add at some point:
- 
+
 * HTML output to include branch - Right now they're just timestamps which makes filtering hard.
 * Document setting branch/commit to handle when CI doesn't set it correctly.
 * Add rake for submitting reports.

--- a/pig_ci.gemspec
+++ b/pig_ci.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'colorize', '>= 0.8.1'
   spec.add_dependency 'get_process_mem', '~> 0.2.3'
   spec.add_dependency 'httparty', '>= 0.16'
-  spec.add_dependency 'i18n', '~> 0.9'
+  spec.add_dependency 'i18n', '>= 0.9', '< 2'
   spec.add_dependency 'rails', '>= 4.2.0'
   spec.add_dependency 'terminal-table', '~> 1.8.0'
 

--- a/pig_ci.gemspec
+++ b/pig_ci.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'colorize', '>= 0.8.1'
   spec.add_dependency 'get_process_mem', '~> 0.2.3'
   spec.add_dependency 'httparty', '>= 0.16'
-  spec.add_dependency 'i18n', '>= 1.0'
+  spec.add_dependency 'i18n', '>= 0.9', '~> 1.0'
   spec.add_dependency 'rails', '>= 4.2.0'
   spec.add_dependency 'terminal-table', '~> 1.8.0'
 

--- a/pig_ci.gemspec
+++ b/pig_ci.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'colorize', '>= 0.8.1'
   spec.add_dependency 'get_process_mem', '~> 0.2.3'
   spec.add_dependency 'httparty', '>= 0.16'
-  spec.add_dependency 'i18n', '>= 0.9', '~> 1.0'
+  spec.add_dependency 'i18n', '~> 0.9'
   spec.add_dependency 'rails', '>= 4.2.0'
   spec.add_dependency 'terminal-table', '~> 1.8.0'
 


### PR DESCRIPTION
This PR allows for i18n gem version 0.9 and above. Previously, it was restricted to 1.0 and above. We are on rails 4.2.11.1, and activesupport has a requirement for i18n (~> 0.7).

Additionally, this corrects a typo in the README for running `rake spec` instead of `rake test`.

Apologies for the multiple commits, was trying to make this work. You should probably squash :)