### PR TITLE
Handling JSON response for API key being incorrect with correct error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * TODO: Deprecate pigci.com integration.
 
+## 0.2.1
+
+* [Handling JSON response for API key being incorrect with correct error](https://github.com/PigCI/pig-ci-rails/pull/23)
+
 ## 0.2.0
 
 * [Updating TravisCI to test latest ruby versions](https://github.com/PigCI/pig-ci-rails/pull/15)

--- a/lib/pig_ci/api/reports.rb
+++ b/lib/pig_ci/api/reports.rb
@@ -10,7 +10,11 @@ class PigCI::Api::Reports < PigCI::Api
       return
     end
 
-    puts I18n.t('pig_ci.api.reports.error', error: JSON.parse(response.parsed_response || '{}')['error'])
+    if response.parsed_response.is_a?(Hash)
+      puts I18n.t('pig_ci.api.reports.error', error: response.parsed_response.dig('error'))
+    else
+      puts I18n.t('pig_ci.api.reports.error')
+    end
   rescue JSON::ParserError => _e
     puts I18n.t('pig_ci.api.reports.api_error')
   rescue SocketError => e

--- a/spec/lib/pig_ci/api/reports_spec.rb
+++ b/spec/lib/pig_ci/api/reports_spec.rb
@@ -48,7 +48,7 @@ describe PigCI::Api::Reports do
         stub_request(:post, 'https://api.pigci.com/api/v1/reports')
           .to_return(status: 401, body: {
             error: 'API Key is invalid'
-          }.to_json)
+          }.to_json, headers: { 'Content-Type' => 'application/json' })
       end
 
       it do


### PR DESCRIPTION
Currently when the API key is invalid, an error would be thrown like:

```
no implicit conversion of Hash into String (TypeError)
```

Going forward, this will throw the nicer error:

```
Unable to connect to PigCI API: API Key is invalid
```