### PR TITLE
Stop GitHub actions not to run on commit

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
-        version: 2.6.x
+        ruby-version: 2.6.x
 
     - name: Publish to GPR
       run: |

--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -3,6 +3,7 @@ name: Build & Publish Ruby Gem
 on:
   create:
     tags:
+      - v*
 
 jobs:
   build:


### PR DESCRIPTION
I didn't have a tag filter, so it was emailing me errors.