### PR TITLE
Skip tracking on specific tests via RSpec metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 1.0.1 (In development)
+## 1.1.0 (In development)
 
+* [Skip tracking on specific tests via RSpec metadata](https://github.com/PigCI/pig-ci-rails/pull/32)
 * [Adding Docker for gem development](https://github.com/PigCI/pig-ci-rails/pull/31)
 
 ## 1.0.0

--- a/README.md
+++ b/README.md
@@ -116,6 +116,22 @@ PigCI.start do |config|
 end
 ```
 
+## Skipping individual tests
+
+If you have a scenario where you'd like PigCI to not log a specific test, you can add the RSpec metadata `pig_ci: true`. For example:
+
+```ruby
+RSpec.describe "Comments", type: :request do
+  # This test block will be not be tracked.
+  describe "GET #index", pig_ci: false do
+    it do
+      get comments_path
+      expect(response).to be_successful
+    end
+  end
+end
+```
+
 ## Authors
 
 * This gem was made by [@MikeRogers0](https://github.com/MikeRogers0).

--- a/lib/pig_ci.rb
+++ b/lib/pig_ci.rb
@@ -16,6 +16,11 @@ module PigCI
 
   attr_accessor :pid
 
+  attr_writer :enabled
+  def enabled?
+    @enabled.nil? ? true : @enabled
+  end
+
   attr_writer :tmp_directory
   def tmp_directory
     @tmp_directory || Pathname.new(Dir.getwd).join('tmp', 'pig-ci')

--- a/lib/pig_ci.rb
+++ b/lib/pig_ci.rb
@@ -10,6 +10,7 @@ require 'pig_ci/profiler_engine'
 require 'pig_ci/profiler'
 require 'pig_ci/metric'
 require 'pig_ci/report'
+require 'pig_ci/test_frameworks'
 
 module PigCI
   extend self
@@ -124,6 +125,7 @@ module PigCI
 
   def start(&block)
     self.pid = Process.pid
+    PigCI::TestFrameworks::Rspec.configure! if defined?(::RSpec)
 
     block.call(self) if block_given?
 

--- a/lib/pig_ci/profiler_engine/rails.rb
+++ b/lib/pig_ci/profiler_engine/rails.rb
@@ -58,17 +58,19 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
     end
 
     ::ActiveSupport::Notifications.subscribe 'sql.active_record' do |_name, _started, _finished, _unique_id, _payload|
-      if request_key?
+      if request_key? && PigCI.enabled?
         profilers.select { |profiler| profiler.class == PigCI::Profiler::DatabaseRequest }.each(&:increment!)
       end
     end
 
     ::ActiveSupport::Notifications.subscribe 'process_action.action_controller' do |_name, _started, _finished, _unique_id, _payload|
-      profilers.each do |profiler|
-        profiler.log_request!(request_key)
-      end
+      if PigCI.enabled?
+        profilers.each do |profiler|
+          profiler.log_request!(request_key)
+        end
 
-      request_captured!
+        request_captured!
+      end
       self.request_key = nil
     end
   end

--- a/lib/pig_ci/test_frameworks.rb
+++ b/lib/pig_ci/test_frameworks.rb
@@ -1,0 +1,3 @@
+module PigCI::TestFrameworks; end
+
+require 'pig_ci/test_frameworks/rspec'

--- a/lib/pig_ci/test_frameworks/rspec.rb
+++ b/lib/pig_ci/test_frameworks/rspec.rb
@@ -1,7 +1,5 @@
 class PigCI::TestFrameworks::Rspec
-  extend self
-
-  def configure!
+  def self.configure!
     ::RSpec.configure do |config|
       config.around(:each, pig_ci: false) do |example|
         @pig_ci_enabled = PigCI.enabled?

--- a/lib/pig_ci/test_frameworks/rspec.rb
+++ b/lib/pig_ci/test_frameworks/rspec.rb
@@ -1,0 +1,22 @@
+class PigCI::TestFrameworks::Rspec
+  extend self
+
+  def configure!
+    ::RSpec.configure do |config|
+      config.around(:each, pig_ci: false) do |example|
+        @pig_ci_enabled = PigCI.enabled?
+        PigCI.enabled = false
+        example.run
+        PigCI.enabled = @pig_ci_enabled
+      end
+
+      config.around(:each, pig_ci: true) do |example|
+        @pig_ci_enabled = PigCI.enabled?
+        PigCI.enabled = true
+        example.run
+        PigCI.enabled = @pig_ci_enabled
+      end
+
+    end if defined?(::RSpec)
+  end
+end

--- a/spec/lib/pig_ci/profiler_engine/rails_spec.rb
+++ b/spec/lib/pig_ci/profiler_engine/rails_spec.rb
@@ -119,6 +119,16 @@ describe PigCI::ProfilerEngine do
           subject
         end
       end
+
+      context 'with PigCI#enabled set to false' do
+        before { PigCI.enabled = false }
+        after { PigCI.enabled = true }
+
+        it do
+          expect(profiler_database_request).to_not receive(:increment!)
+          subject
+        end
+      end
     end
 
     describe 'process_action.action_controller' do
@@ -137,7 +147,24 @@ describe PigCI::ProfilerEngine do
         end
 
         expect { subject }.to change(profiler_engine, :request_captured).from(false).to(true)
-                                                                        .and change(profiler_engine, :request_key).from('request-key').to(nil)
+          .and change(profiler_engine, :request_key).from('request-key').to(nil)
+      end
+
+      context 'with PigCI#enabled set to false' do
+        before { PigCI.enabled = false }
+        after { PigCI.enabled = true }
+
+        it do
+          profiler_engine.profilers.each do |profiler|
+            expect(profiler).to_not receive(:log_request!)
+          end
+
+          expect { subject }.to_not change(profiler_engine, :request_captured)
+        end
+
+        it do
+          expect { subject }.to change(profiler_engine, :request_key).from('request-key').to(nil)
+        end
       end
     end
   end

--- a/spec/lib/pig_ci_spec.rb
+++ b/spec/lib/pig_ci_spec.rb
@@ -36,6 +36,19 @@ describe PigCI do
     end
   end
 
+  describe '::enabled?' do
+    subject { PigCI.enabled? }
+    it { is_expected.to eq(true) }
+
+  end
+
+  describe '::enabled=' do
+    after { PigCI.enabled = true }
+    subject { PigCI.enabled = false }
+
+    it { expect { subject }.to change { PigCI.enabled? }.from(true).to(false) }
+  end
+
   describe '::thresholds.memory' do
     subject { PigCI.thresholds.memory }
     it { is_expected.to eq(350) }


### PR DESCRIPTION
This adds support for the `pig_ci: false` RSpec metadata, e.g.:

```ruby
RSpec.describe "Comments", type: :request do
  # This test block will be not be tracked.
  describe "GET #index", pig_ci: false do
    it do
      get comments_path
      expect(response).to be_successful
    end
  end
end
```

As suggested in https://github.com/PigCI/pig-ci-rails/issues/30 by @ffmike