### PR TITLE
Add option to ignore cached SQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.0 (In development)
 
+* [Add option to ignore cached SQL queries](https://github.com/PigCI/pig-ci-rails/pull/33)
 * [Skip tracking on specific tests via RSpec metadata](https://github.com/PigCI/pig-ci-rails/pull/32)
 * [Adding Docker for gem development](https://github.com/PigCI/pig-ci-rails/pull/31)
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,29 @@ PigCI.start do |config|
 
   # E.g. disable terminal summary output
   config.generate_terminal_summary = false
+
+  # Rails caches repeated SQL queries, you might want to omit these from your report.
+  config.ignore_cached_queries = true
 end # if RSpec.configuration.files_to_run.count > 1
 ```
 
 You can see the full configuration options [lib/pig_ci.rb](https://github.com/PigCI/pig-ci-rails/blob/master/lib/pig_ci.rb#L21).
+
+### Skipping individual tests
+
+If you have a scenario where you'd like PigCI to not log a specific test, you can add the RSpec metadata `pig_ci: true`. For example:
+
+```ruby
+RSpec.describe "Comments", type: :request do
+  # This test block will be not be tracked.
+  describe "GET #index", pig_ci: false do
+    it do
+      get comments_path
+      expect(response).to be_successful
+    end
+  end
+end
+```
 
 ### Framework support
 
@@ -113,22 +132,6 @@ require 'pig_ci'
 PigCI.start do |config|
   config.during_setup_make_blank_application_request = false
   config.during_setup_precompile_assets = false
-end
-```
-
-## Skipping individual tests
-
-If you have a scenario where you'd like PigCI to not log a specific test, you can add the RSpec metadata `pig_ci: true`. For example:
-
-```ruby
-RSpec.describe "Comments", type: :request do
-  # This test block will be not be tracked.
-  describe "GET #index", pig_ci: false do
-    it do
-      get comments_path
-      expect(response).to be_successful
-    end
-  end
 end
 ```
 

--- a/lib/pig_ci.rb
+++ b/lib/pig_ci.rb
@@ -22,6 +22,13 @@ module PigCI
     @enabled.nil? ? true : @enabled
   end
 
+  # Rails caches repeated queries within the same request. You can not count
+  # any cached queries if you'd like.
+  attr_writer :ignore_cached_queries
+  def ignore_cached_queries?
+    @ignore_cached_queries.nil? ? false : @ignore_cached_queries
+  end
+
   attr_writer :tmp_directory
   def tmp_directory
     @tmp_directory || Pathname.new(Dir.getwd).join('tmp', 'pig-ci')

--- a/lib/pig_ci/profiler_engine/rails.rb
+++ b/lib/pig_ci/profiler_engine/rails.rb
@@ -57,8 +57,8 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
       profilers.each(&:reset!)
     end
 
-    ::ActiveSupport::Notifications.subscribe 'sql.active_record' do |_name, _started, _finished, _unique_id, _payload|
-      if request_key? && PigCI.enabled?
+    ::ActiveSupport::Notifications.subscribe 'sql.active_record' do |_name, _started, _finished, _unique_id, payload|
+      if request_key? && PigCI.enabled? && ( !PigCI.ignore_cached_queries? || ( PigCI.ignore_cached_queries? && !payload[:cached] ))
         profilers.select { |profiler| profiler.class == PigCI::Profiler::DatabaseRequest }.each(&:increment!)
       end
     end

--- a/spec/lib/pig_ci_spec.rb
+++ b/spec/lib/pig_ci_spec.rb
@@ -39,7 +39,6 @@ describe PigCI do
   describe '::enabled?' do
     subject { PigCI.enabled? }
     it { is_expected.to eq(true) }
-
   end
 
   describe '::enabled=' do
@@ -47,6 +46,18 @@ describe PigCI do
     subject { PigCI.enabled = false }
 
     it { expect { subject }.to change { PigCI.enabled? }.from(true).to(false) }
+  end
+
+  describe '::ignore_cached_queries?' do
+    subject { PigCI.ignore_cached_queries? }
+    it { is_expected.to eq(false) }
+  end
+
+  describe '::ignore_cached_queries=' do
+    after { PigCI.ignore_cached_queries = false }
+    subject { PigCI.ignore_cached_queries = true }
+
+    it { expect { subject }.to change { PigCI.ignore_cached_queries? }.from(false).to(true) }
   end
 
   describe '::thresholds.memory' do


### PR DESCRIPTION
As suggested in https://github.com/PigCI/pig-ci-rails/issues/26 by @andrewr224.

This add an option to ignore cached SQL queries from the reports. It uses the new `ignore_cached_queries` configuration option, which can be set like so:

```ruby
require 'pig_ci'
PigCI.start do |config|
  # Rails caches repeated SQL queries, you might want to omit these from your report.
  config.ignore_cached_queries = true
end
```