### PR TITLE
Fixing missing logo in output summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.0 (In development)
 
+* [Fixing missing logo in output summary](https://github.com/PigCI/pig-ci-rails/pull/34)
 * [Add option to ignore cached SQL queries](https://github.com/PigCI/pig-ci-rails/pull/33)
 * [Skip tracking on specific tests via RSpec metadata](https://github.com/PigCI/pig-ci-rails/pull/32)
 * [Adding Docker for gem development](https://github.com/PigCI/pig-ci-rails/pull/31)

--- a/lib/pig_ci/views/index.erb
+++ b/lib/pig_ci/views/index.erb
@@ -18,7 +18,7 @@
         <div class="row">
           <div class="col-6">
             <a href="https://pigci.com/" target="_blank" rel="noopener">
-              <img src="https://cdn.pigci.com/logos/pig-ci.svg" class="float-left mr-4" alt="PigCI Logo" />
+              <img src="https://pigci.com/images/logo_pigci.svg" class="float-left mr-4" alt="PigCI Logo" />
             </a>
             <h1><%= I18n.t('.pig_ci.summary.title') %></h1>
           </div>

--- a/lib/pig_ci/views/index.erb
+++ b/lib/pig_ci/views/index.erb
@@ -10,6 +10,8 @@
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+    <link rel="shortcut icon" href="https://pigci.com/images/favicon.png"/>
+    <link rel="icon" type="image/ico" href="https://pigci.com/images/favicon.ico"/>
   </head>
   <body>
 


### PR DESCRIPTION
The logo was linking to the old CDN image from reports generated to `/pig_ci`. I closed down the CDN & I am now linking to the image in the main marketing site.