### PR TITLE
Adding autogenerated changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,38 @@
+name: Changelog
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    if: "!contains(github.event.head_commit.message, '[nodoc]')"
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - uses: actions/cache@v1.1.2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gem-
+    - name: Create local changes
+      run: |
+        gem install github_changelog_generator
+        github_changelog_generator -u PigCI -p pig-ci-rails --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+    - name: Commit files
+      run: |
+        git config --local user.email "github-actions@example.com"
+        git config --local user.name "GitHub Actions"
+        git commit -m "[nodoc] update changelog" -a
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,58 +1,125 @@
 # Changelog
 
-## 1.1.0 (In development)
+## [Unreleased](https://github.com/PigCI/pig-ci-rails/tree/HEAD)
 
-* [Fixing missing logo in output summary](https://github.com/PigCI/pig-ci-rails/pull/34)
-* [Add option to ignore cached SQL queries](https://github.com/PigCI/pig-ci-rails/pull/33)
-* [Skip tracking on specific tests via RSpec metadata](https://github.com/PigCI/pig-ci-rails/pull/32)
-* [Adding Docker for gem development](https://github.com/PigCI/pig-ci-rails/pull/31)
+[Full Changelog](https://github.com/PigCI/pig-ci-rails/compare/v1.0.0...HEAD)
 
-## 1.0.0
+**Closed issues:**
 
-* [Removing PigCI.com integration](https://github.com/PigCI/pig-ci-rails/pull/27) - For more information please [see my announcement](https://pigci.com/github-integration-deprecation-notice).
+- Ignore specific specs? [\#30](https://github.com/PigCI/pig-ci-rails/issues/30)
 
-## 0.2.2
+**Merged pull requests:**
 
-* [Fixing grammar on post_install_message](https://github.com/PigCI/pig-ci-rails/pull/25)
+- Fixing missing logo in output summary [\#34](https://github.com/PigCI/pig-ci-rails/pull/34) ([MikeRogers0](https://github.com/MikeRogers0))
+- Add option to ignore cached SQL queries [\#33](https://github.com/PigCI/pig-ci-rails/pull/33) ([MikeRogers0](https://github.com/MikeRogers0))
+- Skip tracking on specific tests via RSpec metadata [\#32](https://github.com/PigCI/pig-ci-rails/pull/32) ([MikeRogers0](https://github.com/MikeRogers0))
+- Adding in Docker [\#31](https://github.com/PigCI/pig-ci-rails/pull/31) ([MikeRogers0](https://github.com/MikeRogers0))
+- Publishing Package to PigCI account [\#28](https://github.com/PigCI/pig-ci-rails/pull/28) ([MikeRogers0](https://github.com/MikeRogers0))
 
-## 0.2.1
+## [v1.0.0](https://github.com/PigCI/pig-ci-rails/tree/v1.0.0) (2020-04-07)
 
-* [Handling JSON response for API key being incorrect with correct error](https://github.com/PigCI/pig-ci-rails/pull/23)
+[Full Changelog](https://github.com/PigCI/pig-ci-rails/compare/v0.2.2...v1.0.0)
 
-## 0.2.0
+**Merged pull requests:**
 
-* [Updating TravisCI to test latest ruby versions](https://github.com/PigCI/pig-ci-rails/pull/15)
-* [Update rake requirement from ~> 12.3 to ~> 13.0](https://github.com/PigCI/pig-ci-rails/pull/14)
-* [Update rspec requirement from ~> 3.8.0 to ~> 3.9.0](https://github.com/PigCI/pig-ci-rails/pull/16)
-* [Update webmock requirement from ~> 3.7.0 to ~> 3.8.0](https://github.com/PigCI/pig-ci-rails/pull/17)
-* [Adding config.thresholds, this allows standalone usage without pigci.com](https://github.com/PigCI/pig-ci-rails/pull/18) & [Replace references for limit to be threshold](https://github.com/PigCI/pig-ci-rails/pull/21)
-* Setting up repo to publish gem when new tags are created.
+- Removing PigCI.com integration [\#27](https://github.com/PigCI/pig-ci-rails/pull/27) ([MikeRogers0](https://github.com/MikeRogers0))
 
-## 0.1.5
+## [v0.2.2](https://github.com/PigCI/pig-ci-rails/tree/v0.2.2) (2020-03-23)
 
-* [Widen i18n gem version requirement](https://github.com/PigCI/pig-ci-rails/pull/12)
+[Full Changelog](https://github.com/PigCI/pig-ci-rails/compare/v0.2.1...v0.2.2)
 
-## 0.1.4
+**Merged pull requests:**
 
-* [Precompile assets before tests run](https://github.com/PigCI/pig-ci-rails/pull/11)
+- Fixing grammar on post\_install\_message [\#25](https://github.com/PigCI/pig-ci-rails/pull/25) ([MikeRogers0](https://github.com/MikeRogers0))
 
-## 0.1.3
+## [v0.2.1](https://github.com/PigCI/pig-ci-rails/tree/v0.2.1) (2020-03-19)
 
-* [Gracefully handling SockerError when submitting reports while offline](https://github.com/PigCI/pig-ci-rails/pull/7)
-* [Update webmock requirement from ~> 3.6.0 to ~> 3.7.0](https://github.com/PigCI/pig-ci-rails/pull/6)
+[Full Changelog](https://github.com/PigCI/pig-ci-rails/compare/v0.2.0...v0.2.1)
 
-## 0.1.2
+**Merged pull requests:**
 
-* [Improving Codacy Rating](https://github.com/PigCI/pig-ci-rails/pull/4)
-* [Correcting issue where app warm up would negatively affect timezone](https://github.com/PigCI/pig-ci-rails/pull/5)
-* [Adding option to control if app is preloaded or not](https://github.com/PigCI/pig-ci-rails/pull/3)
+- Stop GitHub actions not to run on commit [\#24](https://github.com/PigCI/pig-ci-rails/pull/24) ([MikeRogers0](https://github.com/MikeRogers0))
+- Handling JSON response for API key being incorrect with correct error [\#23](https://github.com/PigCI/pig-ci-rails/pull/23) ([MikeRogers0](https://github.com/MikeRogers0))
 
-## 0.1.1
+## [v0.2.0](https://github.com/PigCI/pig-ci-rails/tree/v0.2.0) (2020-03-18)
 
-* Updating API Endpoints for PigCI.com
-* Adding fallback for if API is down to not fail CI.
-* Removing unnecessary JS,
+[Full Changelog](https://github.com/PigCI/pig-ci-rails/compare/v0.1.5...v0.2.0)
 
-## 0.1.0
+**Merged pull requests:**
 
-* Initial Release
+- Using GitHubs example for gempush.yml [\#22](https://github.com/PigCI/pig-ci-rails/pull/22) ([MikeRogers0](https://github.com/MikeRogers0))
+- Replace references for limit to be threshold [\#21](https://github.com/PigCI/pig-ci-rails/pull/21) ([MikeRogers0](https://github.com/MikeRogers0))
+- Setting up for 0.2.0 release [\#20](https://github.com/PigCI/pig-ci-rails/pull/20) ([MikeRogers0](https://github.com/MikeRogers0))
+- Adding in action for when I tag a new version [\#19](https://github.com/PigCI/pig-ci-rails/pull/19) ([MikeRogers0](https://github.com/MikeRogers0))
+- Adding config.thresholds, this allows standalone usage without pigci.com [\#18](https://github.com/PigCI/pig-ci-rails/pull/18) ([MikeRogers0](https://github.com/MikeRogers0))
+- Update webmock requirement from ~\> 3.7.0 to ~\> 3.8.0 [\#17](https://github.com/PigCI/pig-ci-rails/pull/17) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+- Update rspec requirement from ~\> 3.8.0 to ~\> 3.9.0 [\#16](https://github.com/PigCI/pig-ci-rails/pull/16) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+- Updating TravisCI to test latest ruby versions [\#15](https://github.com/PigCI/pig-ci-rails/pull/15) ([MikeRogers0](https://github.com/MikeRogers0))
+- Update rake requirement from ~\> 12.3 to ~\> 13.0 [\#14](https://github.com/PigCI/pig-ci-rails/pull/14) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+
+## [v0.1.5](https://github.com/PigCI/pig-ci-rails/tree/v0.1.5) (2019-09-23)
+
+[Full Changelog](https://github.com/PigCI/pig-ci-rails/compare/v0.1.4...v0.1.5)
+
+**Merged pull requests:**
+
+- Widen i18n gem version requirement [\#12](https://github.com/PigCI/pig-ci-rails/pull/12) ([mileszim](https://github.com/mileszim))
+
+## [v0.1.4](https://github.com/PigCI/pig-ci-rails/tree/v0.1.4) (2019-09-10)
+
+[Full Changelog](https://github.com/PigCI/pig-ci-rails/compare/v0.1.3...v0.1.4)
+
+**Implemented enhancements:**
+
+- Precompile assets before tests run [\#11](https://github.com/PigCI/pig-ci-rails/pull/11) ([MikeRogers0](https://github.com/MikeRogers0))
+
+**Merged pull requests:**
+
+- Create FUNDING.yml [\#10](https://github.com/PigCI/pig-ci-rails/pull/10) ([MikeRogers0](https://github.com/MikeRogers0))
+
+## [v0.1.3](https://github.com/PigCI/pig-ci-rails/tree/v0.1.3) (2019-08-28)
+
+[Full Changelog](https://github.com/PigCI/pig-ci-rails/compare/v0.1.2...v0.1.3)
+
+**Fixed bugs:**
+
+- Gracefully handling SockerError when submitting reports while offline [\#7](https://github.com/PigCI/pig-ci-rails/pull/7) ([MikeRogers0](https://github.com/MikeRogers0))
+
+**Merged pull requests:**
+
+- Adding Dependabot Status badge to readme [\#9](https://github.com/PigCI/pig-ci-rails/pull/9) ([MikeRogers0](https://github.com/MikeRogers0))
+- Fixing duplicate word typo in readme [\#8](https://github.com/PigCI/pig-ci-rails/pull/8) ([MikeRogers0](https://github.com/MikeRogers0))
+- Update webmock requirement from ~\> 3.6.0 to ~\> 3.7.0 [\#6](https://github.com/PigCI/pig-ci-rails/pull/6) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+
+## [v0.1.2](https://github.com/PigCI/pig-ci-rails/tree/v0.1.2) (2019-08-03)
+
+[Full Changelog](https://github.com/PigCI/pig-ci-rails/compare/v0.1.1...v0.1.2)
+
+**Implemented enhancements:**
+
+- Add options to control eager loading of rails app [\#3](https://github.com/PigCI/pig-ci-rails/pull/3) ([MikeRogers0](https://github.com/MikeRogers0))
+
+**Fixed bugs:**
+
+- Fixing issue where timezone would becomes the machines on app warmup [\#5](https://github.com/PigCI/pig-ci-rails/pull/5) ([MikeRogers0](https://github.com/MikeRogers0))
+
+**Merged pull requests:**
+
+- Fixing up some codacy issues [\#4](https://github.com/PigCI/pig-ci-rails/pull/4) ([MikeRogers0](https://github.com/MikeRogers0))
+
+## [v0.1.1](https://github.com/PigCI/pig-ci-rails/tree/v0.1.1) (2019-07-31)
+
+[Full Changelog](https://github.com/PigCI/pig-ci-rails/compare/v0.1.0...v0.1.1)
+
+**Merged pull requests:**
+
+- Adding fallback for if PigCI is have API issues [\#2](https://github.com/PigCI/pig-ci-rails/pull/2) ([MikeRogers0](https://github.com/MikeRogers0))
+- Adding test coverage with codeclimate [\#1](https://github.com/PigCI/pig-ci-rails/pull/1) ([MikeRogers0](https://github.com/MikeRogers0))
+
+## [v0.1.0](https://github.com/PigCI/pig-ci-rails/tree/v0.1.0) (2019-07-30)
+
+[Full Changelog](https://github.com/PigCI/pig-ci-rails/compare/26699470a370a1ff576f820a0742be5f332561be...v0.1.0)
+
+
+
+\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*


### PR DESCRIPTION
Copied from https://github.com/hopsoft/stimulus_reflex/blob/master/.github/workflows/changelog.yml ( @andrewmcodes wrote this ).

It looks like a way better way of keeping the changelog up-to-date.