### PR TITLE
Only eager loading app in Rails >5.0

### DIFF
--- a/lib/pig_ci/profiler_engine/rails.rb
+++ b/lib/pig_ci/profiler_engine/rails.rb
@@ -35,6 +35,9 @@ class PigCI::ProfilerEngine::Rails < ::PigCI::ProfilerEngine
   end
 
   def eager_load_rails!
+    # None of these methods will work pre-rails 5.
+    return unless ::Rails.version.to_f >= 5.0
+
     # Eager load rails to give more accurate memory levels.
     ::Rails.application.eager_load!
     ::Rails.application.routes.eager_load!

--- a/spec/lib/pig_ci/profiler_engine/rails_spec.rb
+++ b/spec/lib/pig_ci/profiler_engine/rails_spec.rb
@@ -47,6 +47,16 @@ describe PigCI::ProfilerEngine do
     end
   end
 
+  describe '#eager_load_rails!' do
+    subject { profiler_engine.send(:eager_load_rails!) }
+
+    it 'Below Rails 5.2, it does not eager load the app' do
+      expect(::Rails).to receive(:version).and_return('4.2.5')
+      expect(::Rails.application).to_not receive(:eager_load!)
+      subject
+    end
+  end
+
   describe '#make_blank_application_request!' do
     subject { profiler_engine.send(:make_blank_application_request!) }
 


### PR DESCRIPTION
This attempts to fix the issue raised in https://github.com/PigCI/pig-ci-rails/issues/29

The method I was using to eager load the application was added in Rails 5, so in Rails 4 it would throw a method not found method.

This solves it by checking the version number we've running & if it's not Rails 5 or above, just skipping eager loading the app. This will throw off the accuracy of the number returned in the test results, but we'll see if we can work on that later.

Testing this is a little tricky. I've not historically setup any dummy apps for each version of Rails, I might look at setting up something like https://github.com/heartcombo/devise/blob/master/guides/bug_report_templates/integration_test.rb for each version of rails.