### PR TITLE
Removing Aptfile from repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,6 @@ RUN apk add --no-cache $BUILD_DEPS $DEV_DEPS
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# Install any extra dependencies via Aptfile
-COPY Aptfile /usr/src/app/Aptfile
-RUN apk add --update $(cat /usr/src/app/Aptfile | xargs)
-
 # Set up environment
 ENV PATH /usr/src/app/bin:$PATH
 


### PR DESCRIPTION
I used the `Aptfile` for adding explicitly weird packages into the docker images, but in hindsight that was a daft idea.