### PR TITLE
Making GitHub Actions versions less specific

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,11 +12,11 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[nodoc]')"
     steps:
     - uses: actions/checkout@master
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby 2.7
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
-    - uses: actions/cache@v2.1.2
+        ruby-version: 2.7.2
+    - uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Cache gems
-      uses: actions/cache@v2.1.2
+      uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-ruby-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         ruby-version: 2.7
     - name: Cache gems
-      uses: actions/cache@v2.1.2
+      uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
Dependabot kept sending me notifications about patch releases which felt a bit unnecessary as they were all development only.

I'm going to just track major versions for now :)