### PR TITLE
Updating changelog generator to push to master

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,10 @@
+# From: https://github.com/hopsoft/stimulus_reflex/blob/master/.github/workflows/changelog.yml
 name: Changelog
 
 on:
+  workflow_dispatch:
+  release:
+    types: [created]
   push:
     branches:
       - master
@@ -12,27 +16,27 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[nodoc]')"
     steps:
     - uses: actions/checkout@master
-    - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby 3.0
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.2
+        ruby-version: 3.0
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-changelog-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gem-
+          ${{ runner.os }}-changelog-gem-
     - name: Create local changes
       run: |
         gem install github_changelog_generator
-        github_changelog_generator -u PigCI -p pig-ci-rails --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+        github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.event.repository.name }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"
         git config --local user.name "GitHub Actions"
-        git commit -m "[nodoc] update changelog" -a
+        git commit -am "[nodoc] Update Changelog" || echo "No changes to commit"
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-
+        branch: ${{ github.ref }}


### PR DESCRIPTION
https://github.com/ad-m/github-push-action/pull/69 - This PR changed the branch pushed to from `master` to `main`, so explicitly setting the branch is better.