### PR TITLE
Using pigci.mikerogers.io over pigci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@
 
 ![Sample Output of PigCI in TravisCI](https://user-images.githubusercontent.com/325384/78711087-545b6400-790e-11ea-96b7-bb75c119914a.png)
 
-Monitor your Ruby Applications metrics (Memory, SQL Requests & Request Time) as part of your test suite.
-
-Please consider supporting this project by adding [PigCI](https://pigci.com/) to your GitHub project & using this as part of CI. The CI tool will fail PRs that exceed metric threshold (e.g. a big increase in memory).
+Monitor your Ruby Applications metrics (Memory, SQL Requests & Request Time) as part of your test suite. If your app exceeds an acceptable threshold it'll fail the test suite.
 
 ## Installation
 

--- a/config/locales/pig_ci/en.yml
+++ b/config/locales/pig_ci/en.yml
@@ -8,7 +8,7 @@ en:
       view_historic_reports: 'Historic Reports'
       footer_html: |
         <p>Generated <time datetime="%{generated_at}">%{generated_at}</time> by PigCI.</p>
-        <p>Support <a href="https://pigci.com/" target="_blank" rel="noopener">PigCI</a> by <a href="https://github.com/apps/pigci/installations/new" target="_blank" rel="noopener">adding us on GitHub</a>.</p>
+        <p>Support <a href="https://pigci.mikerogers.io/" target="_blank" rel="noopener">PigCI</a> by <a href="https://www.buymeacoffee.com/MikeRogers0" target="_blank" rel="noopener">buying me a coffee</a>.</p>
 
     report:
       memory:

--- a/lib/pig_ci/views/index.erb
+++ b/lib/pig_ci/views/index.erb
@@ -10,8 +10,8 @@
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-    <link rel="shortcut icon" href="https://pigci.com/images/favicon.png"/>
-    <link rel="icon" type="image/ico" href="https://pigci.com/images/favicon.ico"/>
+    <link rel="shortcut icon" href="https://pigci.mikerogers.io/images/favicon.png"/>
+    <link rel="icon" type="image/ico" href="https://pigci.mikerogers.io/images/favicon.ico"/>
   </head>
   <body>
 
@@ -19,8 +19,8 @@
       <header class="py-3">
         <div class="row">
           <div class="col-6">
-            <a href="https://pigci.com/" target="_blank" rel="noopener">
-              <img src="https://pigci.com/images/logo_pigci.svg" class="float-left mr-4" alt="PigCI Logo" />
+            <a href="https://pigci.mikerogers.io/" target="_blank" rel="noopener">
+              <img src="https://pigci.mikerogers.io/images/logo_pigci.svg" class="float-left mr-4" alt="PigCI Logo" />
             </a>
             <h1><%= I18n.t('.pig_ci.summary.title') %></h1>
           </div>

--- a/pig_ci.gemspec
+++ b/pig_ci.gemspec
@@ -45,11 +45,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.10.0'
   spec.add_development_dependency 'simplecov', '~> 0.20.0'
   spec.add_development_dependency 'yard', '~> 0.9.24'
-
-  spec.post_install_message = [
-    'Thank you for installing Pig CI!',
-    'Upgrade Notes:',
-    'The latest version adds a "config.thresholds" option which replaces the PigCI.com GitHub integration.',
-    'See https://github.com/PigCI/pig-ci-rails#configuring-thresholds for more information :)'
-  ].join("\n")
 end


### PR DESCRIPTION
I'm looking to reduce the amount of domains I run day-to-day in favour of subdomains. So I'm moving PigCI to a subdomain later in the month, this prepares that :D 